### PR TITLE
feat: Update getConnectionInfo callback to support handling the pushNotification type

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "ISC",
   "dependencies": {
     "@2060.io/credo-ts-message-pickup-repository-pg": "^0.0.7",
-    "@2060.io/message-pickup-repository-client": "^0.0.7",
+    "@2060.io/message-pickup-repository-client": "^0.0.8",
     "@credo-ts/askar": "0.5.11",
     "@credo-ts/core": "0.5.11",
     "@credo-ts/node": "0.5.11",

--- a/src/agent/initDidCommMediatorAgent.ts
+++ b/src/agent/initDidCommMediatorAgent.ts
@@ -88,7 +88,7 @@ export const initMediator = async (config: CloudAgentOptions) => {
     const getConnectionInfo = async (connectionId: string): Promise<ConnectionInfo | undefined> => {
       const connectionRecord = await agent.connections.findById(connectionId)
       return {
-        fcmNotificationToken: connectionRecord?.getTag('device_token') as string | undefined,
+        pushNotificationToken: { type: 'fcm', token: connectionRecord?.getTag('device_token') as string | undefined },
         maxReceiveBytes: config.messagePickupMaxReceiveBytes,
       }
     }


### PR DESCRIPTION
With the update of the Message Pickup Repository server to support sendPushNotification for FCM and APN, the getConnectionInfo callback is updated with the new ConnectionInfo type to indicate the handling of the push notification server.