### PR TITLE
fix: Update credo-ts-message-pickup-repository-pg version 0.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@2060.io/credo-ts-message-pickup-repository-pg": "0.0.9",
+    "@2060.io/credo-ts-message-pickup-repository-pg": "0.0.10",
     "@2060.io/message-pickup-repository-client": "0.0.8",
     "@credo-ts/askar": "0.5.11",
     "@credo-ts/core": "0.5.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   .:
     dependencies:
       '@2060.io/credo-ts-message-pickup-repository-pg':
-        specifier: 0.0.9
-        version: 0.0.9(@credo-ts/core@0.5.11(expo@52.0.42(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react-native@0.78.1(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(utf-8-validate@5.0.10))(react-native@0.78.1(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(web-streams-polyfill@3.3.3))
+        specifier: 0.0.10
+        version: 0.0.10(@credo-ts/core@0.5.11(expo@52.0.42(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react-native@0.78.1(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(utf-8-validate@5.0.10))(react-native@0.78.1(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(web-streams-polyfill@3.3.3))
       '@2060.io/message-pickup-repository-client':
         specifier: 0.0.8
         version: 0.0.8(@credo-ts/core@0.5.11(expo@52.0.42(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react-native@0.78.1(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(utf-8-validate@5.0.10))(react-native@0.78.1(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(web-streams-polyfill@3.3.3))
@@ -173,9 +173,9 @@ packages:
       graphql:
         optional: true
 
-  '@2060.io/credo-ts-message-pickup-repository-pg@0.0.9':
+  '@2060.io/credo-ts-message-pickup-repository-pg@0.0.10':
     resolution:
-      { integrity: sha512-zyJKeSyYiJo9QRFaMv35hB1ssOH1hItK55AWhMZGZGgiYf3crXyaEyIbduAiaVDY+v7rY7xF4o/a5fI015LdMg== }
+      { integrity: sha512-TXRJiDkgJGM2l1CNtQVd2x0QdIGoituEqUlO8t9L4utW/LmQstjwGYBMlDHypizgn4myMnKUXKd4r2FuXqtQQQ== }
     peerDependencies:
       '@credo-ts/core': 0.5.11
 
@@ -7706,7 +7706,7 @@ snapshots:
   '@0no-co/graphql.web@1.1.2':
     optional: true
 
-  '@2060.io/credo-ts-message-pickup-repository-pg@0.0.9(@credo-ts/core@0.5.11(expo@52.0.42(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react-native@0.78.1(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(utf-8-validate@5.0.10))(react-native@0.78.1(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(web-streams-polyfill@3.3.3))':
+  '@2060.io/credo-ts-message-pickup-repository-pg@0.0.10(@credo-ts/core@0.5.11(expo@52.0.42(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react-native@0.78.1(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(utf-8-validate@5.0.10))(react-native@0.78.1(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(web-streams-polyfill@3.3.3))':
     dependencies:
       '@credo-ts/core': 0.5.11(expo@52.0.42(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react-native@0.78.1(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(utf-8-validate@5.0.10))(react-native@0.78.1(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(web-streams-polyfill@3.3.3)
       pg: 8.14.1


### PR DESCRIPTION
Introduce update to @2060.io/credo-ts-message-pickup-repository-pg package 0.0.10 that resolve the following error:

```bash
[takeFromQueue] Error: error: column "encryptedmessage" does not exist
```
This update ensures the column name is aligned with the current schema and prevents runtime failures during message retrieval.