### PR TITLE
fix: use exact packaged filename for Helm OCI push

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -110,6 +110,7 @@ jobs:
         if: steps.semantic.outputs.new-release-published == 'true'
         run: |
           sed -i "s/^version:.*/version: $RELEASE_VERSION/" ./charts/Chart.yaml
+          CHART_NAME=$(grep '^name:' ./charts/Chart.yaml | awk '{print $2}')
           helm dependency update ./charts
           helm package ./charts -d ./charts
-          helm push ./charts/$IMAGE_NAME-$RELEASE_VERSION.tgz oci://docker.io/$DH_USERNAME
+          helm push ./charts/$CHART_NAME-$RELEASE_VERSION.tgz oci://docker.io/$DH_USERNAME


### PR DESCRIPTION
Capture the exact .tgz filename generated by helm package (which includes the -chart suffix) and use it in helm push, eliminating the hard-coded name mismatch that caused the previous failure.