### PR TITLE
fix: Image charts template

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: {{ .Values.statefulset.containerName }}
-          image: "io2060/didcomm-mediator:{{ .Chart.AppVersion }}"
+          image: io2060/didcomm-mediator:{{ .Chart.Version }}
           imagePullPolicy: {{ .Values.statefulset.image.pullPolicy }}
           ports:
             - containerPort: 4000


### PR DESCRIPTION
Replaces incorrect Chart.Appversion with Chart.Version which caused deployment mount image dev