### PR TITLE
fix: Add "v" to version push helm chart to docker hub OCI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Push Helm chart to Docker Hub OCI repo
         if: steps.semantic.outputs.new-release-published == 'true'
         run: |
-          sed -i "s/^version:.*/version: $RELEASE_VERSION/" ./charts/Chart.yaml
+          sed -i "s/^version:.*/version: v$RELEASE_VERSION/" ./charts/Chart.yaml
           CHART_NAME=$(grep '^name:' ./charts/Chart.yaml | awk '{print $2}')
           helm dependency update ./charts
           helm package ./charts -d ./charts

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -113,4 +113,4 @@ jobs:
           CHART_NAME=$(grep '^name:' ./charts/Chart.yaml | awk '{print $2}')
           helm dependency update ./charts
           helm package ./charts -d ./charts
-          helm push ./charts/$CHART_NAME-$RELEASE_VERSION.tgz oci://docker.io/$DH_USERNAME
+          helm push ./charts/$CHART_NAME-v$RELEASE_VERSION.tgz oci://docker.io/$DH_USERNAME


### PR DESCRIPTION
Add the "v" to version generare from release please in  helm push OCI