### PR TITLE
feat: release updated shorten-url integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # DIDComm Mediator
 
+## Prerequisites
+
+- Node.js 22
+- pnpm 9 (installable via `corepack enable`)
+- Docker/Docker Compose if you plan to run the containerized setup
+
 ## Configuration
 
 ### Environment variables


### PR DESCRIPTION
There was an error in the previous PR the commit didn’t follow the Conventional Commits format, so semantic-release didn’t create a release.