### PR TITLE
fix: public DID checking on connection requests

### DIFF
--- a/src/agent/DidCommMediatorAgent.ts
+++ b/src/agent/DidCommMediatorAgent.ts
@@ -159,9 +159,9 @@ export class DidCommMediatorAgent extends Agent {
         if (hasLegacyMethods) await this.createAndAddDidCommKeysAndServices(didDocument)
 
         await this.dids.update({ did: didDocument.id, didDocument })
-        this.logger?.debug('Public did record updated')
+        this.logger?.debug(`Public did record updated. Agent public DID: ${this.did}`)
       } else {
-        this.logger?.debug('Existing DID record found. No updates')
+        this.logger?.debug(`Existing DID record found. No updates. Agent public DID: ${this.did}`)
       }
       this.did = existingRecord.did
     }

--- a/src/agent/initDidCommMediatorAgent.ts
+++ b/src/agent/initDidCommMediatorAgent.ts
@@ -219,10 +219,10 @@ export const initMediator = async (
         if (connection.outOfBandId && payload.connectionRecord.state === DidCommDidExchangeState.RequestReceived) {
           const oob = await agent.didcomm.oob.findById(connection.outOfBandId)
           const invitationId = oob?.outOfBandInvitation?.id ?? oob?.outOfBandInvitation?.invitationId
-          if (invitationId === publicDid) {
-            logger.debug(`Incoming connection request for ${publicDid}`)
+          if (invitationId === agent.did) {
+            logger.debug(`Incoming connection request for ${agent.did}`)
             await agent.didcomm.connections.acceptRequest(connection.id)
-            logger.debug(`Accepted request for ${publicDid}`)
+            logger.debug(`Accepted request for ${agent.did}`)
           }
         }
       }


### PR DESCRIPTION
The previous check worked for did:web because it was exactly the same as the AGENT_PUBLIC_DID, but with did:webvh it will not work, since we are missing the SCID. So now we will check against the actual DID the agent has created.